### PR TITLE
Add standalone signup page

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sign Up - BeautyFind</title>
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Custom Styles -->
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="bg-gray-50 font-poppins">
+  <div class="min-h-screen flex items-center justify-center px-4">
+    <form id="signupForm" class="bg-white rounded-2xl shadow-lg w-full max-w-md p-8 space-y-6">
+      <h2 class="text-3xl font-playfair font-bold text-center text-primary">Create Account</h2>
+      <div>
+        <label for="signUpName" class="block text-sm font-medium text-deep-charcoal mb-2">Name</label>
+        <input type="text" id="signUpName" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent">
+      </div>
+      <div>
+        <label for="signUpEmail" class="block text-sm font-medium text-deep-charcoal mb-2">Email</label>
+        <input type="email" id="signUpEmail" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent">
+      </div>
+      <div>
+        <label for="signUpPassword" class="block text-sm font-medium text-deep-charcoal mb-2">Password</label>
+        <input type="password" id="signUpPassword" required minlength="6" class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent">
+      </div>
+      <div id="signupError" class="hidden text-red-600 text-sm"></div>
+      <button type="submit" class="w-full btn-accent">Sign Up</button>
+    </form>
+  </div>
+  <script src="assets/js/auth.js"></script>
+  <script>
+    const form = document.getElementById('signupForm');
+    const errorDiv = document.getElementById('signupError');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errorDiv.classList.add('hidden');
+      const name = document.getElementById('signUpName').value;
+      const email = document.getElementById('signUpEmail').value;
+      const password = document.getElementById('signUpPassword').value;
+      const submitBtn = form.querySelector('button[type="submit"]');
+      const originalText = submitBtn.textContent;
+      submitBtn.textContent = 'Creating Account...';
+      submitBtn.disabled = true;
+      try {
+        const result = await authManager.signUpWithEmail(email, password, name);
+        if (result.success) {
+          window.location.href = 'Index.html';
+        } else {
+          errorDiv.textContent = result.error;
+          errorDiv.classList.remove('hidden');
+        }
+      } catch (err) {
+        errorDiv.textContent = 'An unexpected error occurred. Please try again.';
+        errorDiv.classList.remove('hidden');
+      } finally {
+        submitBtn.textContent = originalText;
+        submitBtn.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated signup.html page with Tailwind styling
- integrate page with existing auth manager to create user account and redirect to home

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895253b09d4832a8655ac78a96072c9